### PR TITLE
Allow for optional attributes to not be provided for check connection request.

### DIFF
--- a/com/plugin/go/nuget/RepositoryConfigHandler.java
+++ b/com/plugin/go/nuget/RepositoryConfigHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,8 @@ public class RepositoryConfigHandler extends PluginConfigHandler {
         Map configMap = (Map) request.get("repository-configuration");
         Map urlMap = (Map) configMap.get("REPO_URL");
 
-        if (urlMap.get("value").equals("")) {
+        Object repoUrl = urlMap.get("value");
+        if (repoUrl == null || repoUrl.equals("")) {
             Map errors = new HashMap();
             errors.put("key", "REPO_URL");
             errors.put("message", "Url cannot be empty");
@@ -68,7 +69,10 @@ public class RepositoryConfigHandler extends PluginConfigHandler {
 
     private String parseValueFromEmbeddedMap(Map configMap, String fieldName) {
         Map fieldMap = (Map) configMap.get(fieldName);
-        String value = (String) fieldMap.get("value");
+        String value = null;
+        if (fieldMap != null) {
+            value = (String) fieldMap.get("value");
+        }
         return value;
     }
 

--- a/test/plugin/go/nuget/unit/RepositoryConfigHandlerTest.java
+++ b/test/plugin/go/nuget/unit/RepositoryConfigHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,16 @@ public class RepositoryConfigHandlerTest {
 
     @Test
     public void shouldErrorWhenInvalidRepositoryConfiguration() {
-        Map invalidBody = createUrlRequestBody("", "", "");
+        Map invalidBody = createRequestBodyWithCompleteMetadata("", "", "");
+
+        List errorList = repositoryConfigHandler.handleValidateConfiguration(invalidBody);
+
+        Assert.assertFalse(errorList.isEmpty());
+    }
+
+    @Test
+    public void shouldErrorOutWhenRepoUrlIsNull() {
+        Map invalidBody = createRequestBodyWithCompleteMetadata(null, "", "");
 
         List errorList = repositoryConfigHandler.handleValidateConfiguration(invalidBody);
 
@@ -52,7 +61,7 @@ public class RepositoryConfigHandlerTest {
 
     @Test
     public void shouldReturnEmptyErrorListWhenValidRepositoryConfigurations() {
-        Map validBody = createUrlRequestBody("http://testsite.com", "", "");
+        Map validBody = createRequestBodyWithCompleteMetadata("http://testsite.com", "", "");
 
         List errorList = repositoryConfigHandler.handleValidateConfiguration(validBody);
 
@@ -65,12 +74,31 @@ public class RepositoryConfigHandlerTest {
         String SOME_USERNAME = "SomeUsername";
         String SOME_PASSWORD = "somePassword";
 
-        repositoryConfigHandler.handleCheckRepositoryConnection(createUrlRequestBody(SOME_URL, SOME_USERNAME, SOME_PASSWORD));
+        repositoryConfigHandler.handleCheckRepositoryConnection(createRequestBodyWithCompleteMetadata(SOME_URL, SOME_USERNAME, SOME_PASSWORD));
 
         verify(connectionHandler).checkConnectionToUrlWithMetadata(SOME_URL, SOME_USERNAME, SOME_PASSWORD);
     }
 
-    private Map createUrlRequestBody(String url, String username, String password) {
+    @Test
+    public void shouldHandleCheckConnectionWhenOptionalMetadataIsNotProvided() {
+        String SOME_URL = "http://www.nuget.com/";
+
+        repositoryConfigHandler.handleCheckRepositoryConnection(createUrlRequestBody(SOME_URL));
+
+        verify(connectionHandler).checkConnectionToUrlWithMetadata(SOME_URL, null, null);
+    }
+
+    private Map createUrlRequestBody(String url) {
+        Map urlMap = new HashMap();
+        urlMap.put("value", url);
+        Map fieldsMap = new HashMap();
+        fieldsMap.put("REPO_URL", urlMap);
+        Map bodyMap = new HashMap();
+        bodyMap.put(REPOSITORY_CONFIGURATION, fieldsMap);
+        return bodyMap;
+    }
+
+    private Map createRequestBodyWithCompleteMetadata(String url, String username, String password) {
         Map urlMap = new HashMap();
         urlMap.put("value", url);
         Map fieldsMap = new HashMap();


### PR DESCRIPTION
* Handle validation when REPO_URL is null or empty.

@alisonps and @salliewalecka - Please review.
1. The REPO_URL can be null (not just blank) if the package repository is being created via the [Package repository API](https://api.gocd.io/current/#create-a-repository)

2. While handling the check connection request, the username and password may not be provided. The ```parseValueFromEmbeddedMap``` throws a NullPointerException. This PR fixes that. 